### PR TITLE
Scrape the new 6th Legislative Council pages instead

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -89,7 +89,7 @@ def scrape_person(url)
 
   data = {
     id: id,
-    term: 5,
+    term: 6,
     name: name,
     honorific_suffix: name_suffix,
     honorific_prefix: honorific_prefix,
@@ -108,13 +108,4 @@ def scrape_person(url)
   ScraperWiki.save_sqlite([:id], data)
 end
 
-term = {
-  id: 5,
-  name: 'Fifth Legislative Council',
-  start_date: '2012-09-12',
-  source: 'http://www.legco.gov.hk/general/english/intro/hist_lc.htm',
-}
-
-ScraperWiki.save_sqlite([:id], term, 'terms')
-
-scrape_list('http://www.legco.gov.hk/general/english/members/yr12-16/biographies.htm')
+scrape_list("http://www.legco.gov.hk/general/english/members/yr16-20/biographies.htm")


### PR DESCRIPTION
There has recently been an election in Hong Kong. We have archived the
data from the 5th Legislative Council, but now need to update the scraper
to fetch members from the new 6th Legislative Council instead.

(Note for the pull request, not in the commit mesage: the plan is to deploy
this under the everypolitician-scrapers account on morph.io.)
