### PR TITLE
Use the pseudo-party 'Independent' as faction when it's unknown

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -79,6 +79,7 @@ def scrape_person(url)
     faction = fix_parties(faction)
   else
     faction = faction.to_s.tidy
+    faction = 'Independent' if faction.empty?
   end
 
   email = bio.xpath('//table/tr/td/a[contains(@href, "mailto")]/text()').to_s.tidy


### PR DESCRIPTION
This will make the grouping of parties on everypolitician.org easier to
relate to that on Wikipedia, for example.
