### PR TITLE
Update rubocop, scraper_test and scraped gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+AllCops:
+  Exclude:
+    - 'Vagrantfile'
+    - 'vendor/**/*'
+  TargetRubyVersion: 2.3
+
+inherit_from: 
+  - https://raw.githubusercontent.com/everypolitician/everypolitician-data/master/.rubocop_base.yml
+  - .rubocop_todo.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
-    parser (2.3.3.1)
+    parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.4)
@@ -84,15 +84,16 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.5)
-    rainbow (2.1.0)
+    rainbow (2.2.2)
+      rake
     rake (12.0.0)
     require_all (1.4.0)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rubocop (0.46.0)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.48.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -106,7 +107,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode-display_width (1.1.2)
+    unicode-display_width (1.2.1)
     vcr (3.0.3)
     vcr-archive (0.3.0)
       vcr (~> 3.0.2)
@@ -141,4 +142,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,10 +17,10 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/scraper_test.git
-  revision: a217cbd51d0544261c059f877628ed384b8844ac
+  revision: a8a6c795ea1544bc95e2f7a1dbb132ba8c80ed98
   specs:
     scraper_test (0.1.0)
-      minitest
+      minitest (~> 5.0)
       pry
       vcr (>= 3.0.3)
       webmock (>= 2.0)
@@ -44,7 +44,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)
     coderay (1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/everypolitician/scraped.git
-  revision: c2e9db21e2922d8d8053bf7fa763228a0373db79
+  revision: 23a9620a8b0cd3bf1c6ac6e99c8eb97b3906bb94
   specs:
-    scraped (0.3.0)
+    scraped (0.6.0)
       field_serializer (>= 0.3.0)
       nokogiri
       require_all
@@ -73,7 +73,7 @@ GEM
       minitest (>= 4.7.5)
       vcr (>= 2.9)
     netrc (0.11.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
     parser (2.4.0.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
+
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
-task default: %w(rubocop)
+task default: %w[rubocop]


### PR DESCRIPTION
Updates to latest version of rubocop. Ruby style guide now prefers `%w[...]` over `%w(...)`. The latest version of Rubocop checks for this.

Latest version of `scraper_test` provides name spaced test `test:data`. This is required so that custom tests can be run alongside `scraper_test` tests/

Latest version of `scraped` provides `CleanUrls` decorator. This is required as `AbsoluteUrls` decorator is deprecated.