### PR TITLE
Run rake tasks before ensure-regression-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
 sudo: false
 cache: bundler
 script:
-  - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/v0.1.0/ensure-regression-tests)
   - bundle exec rake
+  - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/v0.1.0/ensure-regression-tests)


### PR DESCRIPTION
ensure-regression-tests does not tidy up after itself. Executing rake default first ensures that any tests are run against the current branch, not the target branch of ensure-regression-tests.